### PR TITLE
Improving deepest element search in visual-selector 

### DIFF
--- a/changedetectionio/res/xpath_element_scraper.js
+++ b/changedetectionio/res/xpath_element_scraper.js
@@ -140,6 +140,7 @@ for (var i = 0; i < elements.length; i++) {
         xpath: xpath_result,
         width: Math.round(bbox['width']),
         height: Math.round(bbox['height']),
+        square: Math.round(bbox['width'])*Math.round(bbox['height']),
         left: Math.floor(bbox['left']),
         top: Math.floor(bbox['top'])+scroll_y,
         tagName: (elements[i].tagName) ? elements[i].tagName.toLowerCase() : '',

--- a/changedetectionio/res/xpath_element_scraper.js
+++ b/changedetectionio/res/xpath_element_scraper.js
@@ -140,7 +140,6 @@ for (var i = 0; i < elements.length; i++) {
         xpath: xpath_result,
         width: Math.round(bbox['width']),
         height: Math.round(bbox['height']),
-        square: Math.round(bbox['width'])*Math.round(bbox['height']),
         left: Math.floor(bbox['left']),
         top: Math.floor(bbox['top'])+scroll_y,
         tagName: (elements[i].tagName) ? elements[i].tagName.toLowerCase() : '',

--- a/changedetectionio/static/js/visual-selector.js
+++ b/changedetectionio/static/js/visual-selector.js
@@ -175,8 +175,9 @@ $(document).ready(function () {
             }
 
             // Reverse order - the most specific one should be deeper/"laster"
-            // Basically, find the most 'deepest'
-            var found = 0;
+            // Basically, find the most 'deepest' and smallest square
+            var found = null;
+            var minSquare = Infinity;
             ctx.fillStyle = 'rgba(205,0,0,0.35)';
             // Will be sorted by smallest width*height first
             for (var i = 0; i <= selector_data['size_pos'].length; i++) {
@@ -186,22 +187,24 @@ $(document).ready(function () {
                 if (e.offsetY > sel.top * y_scale && e.offsetY < sel.top * y_scale + sel.height * y_scale
                     &&
                     e.offsetX > sel.left * y_scale && e.offsetX < sel.left * y_scale + sel.width * y_scale
-
+                    &&
+                    sel.square < minSquare
                 ) {
 
                     // FOUND ONE
-                    set_current_selected_text(sel.xpath);
-                    ctx.strokeRect(sel.left * x_scale, sel.top * y_scale, sel.width * x_scale, sel.height * y_scale);
-                    ctx.fillRect(sel.left * x_scale, sel.top * y_scale, sel.width * x_scale, sel.height * y_scale);
+                    found = sel;
 
                     // no need to keep digging
                     // @todo or, O to go out/up, I to go in
                     // or double click to go up/out the selector?
                     current_selected_i = i;
-                    found += 1;
-                    break;
+                    minSquare = sel.square;
                 }
             }
+            
+            set_current_selected_text(found.xpath);
+            ctx.strokeRect(found.left * x_scale, found.top * y_scale, found.width * x_scale, found.height * y_scale);
+            ctx.fillRect(found.left * x_scale, found.top * y_scale, found.width * x_scale, found.height * y_scale);
 
         }.debounce(5));
 

--- a/changedetectionio/static/js/visual-selector.js
+++ b/changedetectionio/static/js/visual-selector.js
@@ -188,7 +188,7 @@ $(document).ready(function () {
                     &&
                     e.offsetX > sel.left * y_scale && e.offsetX < sel.left * y_scale + sel.width * y_scale
                     &&
-                    sel.square < minSquare
+                    sel.width * sel.height < minSquare
                 ) {
 
                     // FOUND ONE
@@ -198,7 +198,7 @@ $(document).ready(function () {
                     // @todo or, O to go out/up, I to go in
                     // or double click to go up/out the selector?
                     current_selected_i = i;
-                    minSquare = sel.square;
+                    minSquare = sel.width * sel.height;
                 }
             }
             


### PR DESCRIPTION
- added extra condition when element considered to be the correct one on mousemove event: it has to have the smallest square